### PR TITLE
BibLatex support for NTNU beamer theme & Travis CI test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+# Travis CI configuration file
+notifications:
+  email: false
+
+dist: trusty
+
+sudo: required
+
+addons:
+  apt:
+    packages:
+      - texlive-full
+      - biber
+
+script:
+  - make -C beamerntnu2015

--- a/beamerntnu2015/Makefile
+++ b/beamerntnu2015/Makefile
@@ -1,0 +1,13 @@
+#
+# Example Makefile for Unix(-like) systems with pdflatex
+# 
+
+default:
+	pdflatex -halt-on-error -interaction=nonstopmode example.tex
+	pdflatex -halt-on-error -interaction=nonstopmode example.tex
+
+	pdflatex -halt-on-error -interaction=nonstopmode example2.tex
+	pdflatex -halt-on-error -interaction=nonstopmode example2.tex
+	biber example2
+	pdflatex -halt-on-error -interaction=nonstopmode example2.tex
+	pdflatex -halt-on-error -interaction=nonstopmode example2.tex

--- a/beamerntnu2015/beamerthementnu2015.sty
+++ b/beamerntnu2015/beamerthementnu2015.sty
@@ -276,5 +276,14 @@
 \setbeamerfont{pagenumber}{size=\small,series=\bfseries}
 
 
+% Textpos conflicts with biblatex, they both define ifboolexpr.
+% This is a workaround to undefine the conflicting macro.
+% But we only undefine it, if it was defined. (textpos might change later)
+\ifcsname ifboolexpr\endcsname
+\makeatletter
+\let\ifboolexpr\@undefined
+\makeatother
+\fi
+
 \mode
 <all>

--- a/beamerntnu2015/example2.bib
+++ b/beamerntnu2015/example2.bib
@@ -1,0 +1,6 @@
+@misc{latex,
+  title={A beginner’s introduction to typesetting with LATEX},
+  author={Flynn, Peter},
+  year={2005},
+  url={http://ctan.ijs.si/tex-archive/documentation/beginlatex/src/old/beginlatex.letter.pdf}
+}

--- a/beamerntnu2015/example2.tex
+++ b/beamerntnu2015/example2.tex
@@ -1,0 +1,47 @@
+\documentclass[screen, aspectratio=43]{beamer}
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+
+% Use the NTNU-temaet for beamer 
+% \usetheme[style=ntnu|simple|vertical|horizontal, language=bm|nn|en]{ntnu2015}
+\usetheme[style=ntnu,language=en]{ntnu2015}
+
+\usepackage[english]{babel}
+\usepackage[style=numeric,backend=biber,natbib=false,sorting=none]{biblatex}
+
+\title[Short title]{The full and long title of the presentation}
+\subtitle{Subtitle if you want}
+\author[O. Nordmann]{Ola Nordmann}
+\institute[NTNU]{Department of LaTeX-ical sciences, NTNU}
+\date{1 January 1970}
+%\date{} % To have an empty date
+
+\addbibresource{example2.bib} % Add bibliography database
+
+% Set the reference style to numeric.
+% See here: http://tex.stackexchange.com/questions/68080/beamer-bibliography-icon
+\setbeamertemplate{bibliography item}[text] 
+
+% Set bibliography fonts to a small size.
+\renewcommand*{\bibfont}{\footnotesize}
+
+
+\begin{document}
+
+% Special title page command to get a different background
+\ntnutitlepage
+
+\begin{frame}
+  \frametitle{Main theorem}
+  \begin{theorem}
+    LaTeX makes things easier\cite{latex}.
+  \end{theorem}
+\end{frame}
+
+
+\begin{frame}
+  \frametitle{References}
+  \printbibliography
+\end{frame}
+
+\end{document}


### PR DESCRIPTION
The NTNU theme breaks Biblatex (at least in my setup). The reason is a conflict with 'textpos' package which defines a new macro. On long term termpos, biblatex and/or beamer should be fixed, but there is a short term workaround: undefine the macro before biblatex.

It would be nice to test if the theme actually works, so I added a Travis CI integration. ( https://travis-ci.org )
Travis can build the repository, and check it for errors at every single commit. It is free for open source projects hosted at github.

It looks like this (for my fork): https://travis-ci.org/dvolgyes/beamerthementnu

The integration test involves the original compiled example (example.tex) and a new example with citation. (biber/biblatex).

Travis setup: if the travis integration is enabled for the repository before the merge, then the pull request will be tested too. If not, then only new commits will be tested, which are not too frequent.
